### PR TITLE
Install cherrypy_cors.

### DIFF
--- a/server.py
+++ b/server.py
@@ -9,6 +9,7 @@ CherryPy-based webservice daemon with background threads
 import threading
 import json
 import cherrypy
+import cherrypy_cors
 from cherrypy.process import plugins
 
 sample_nodes = [
@@ -132,6 +133,8 @@ def jsonify_error(status, message, traceback, version): \
 
 
 if __name__ == '__main__':
+    cherrypy_cors.install()
+
     MyBackgroundThread(cherrypy.engine).subscribe()
 
     dispatcher = cherrypy.dispatch.RoutesDispatcher()
@@ -169,6 +172,7 @@ if __name__ == '__main__':
         '/': {
             'request.dispatch': dispatcher,
             'error_page.default': jsonify_error,
+            'cors.expose.on': True,
         },
     }
 


### PR DESCRIPTION
As requested in yougov/cherrypy-cors#6, this provides an example of using the CORS tools in a Routes-dispatched App (though the presence of routes is not a factor).

I ran this script with:

```
$ rwt cherrypy cherrypy-cors routes -- ./server.py
```

And then tested it:

```
$ curl -i -H 'Origin: http://localhost:8080/nodes' http://localhost:8080/nodes
HTTP/1.1 200 OK
Content-Type: application/json
Server: CherryPy/14.0.0
Date: Wed, 07 Feb 2018 21:26:49 GMT
Access-Control-Allow-Origin: http://localhost:8080/nodes
Vary: Origin
Content-Length: 38

[{"name": "node1"}, {"name": "node2"}]%
```

As you can see, with the Origin header supplied by the requester, the relevant Access-Control-Allow-Origin and Vary headers are supplied.